### PR TITLE
Copy compilation failure test to Kassert project

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,3 +4,10 @@ include(GoogleTest)
 
 kassert_register_test(test_kassert_assertion_mode FILES kassert_test.cpp)
 kassert_register_test(test_kassert_exception_mode EXCEPTION_MODE FILES kassert_test.cpp)
+
+kassert_register_compilation_failure_test(
+  TARGET test_kassert_compilation_failure
+  FILES kassert_compilation_failures_test.cpp 
+  SECTIONS "FORBIDDEN_AND" "FORBIDDEN_OR"
+  LIBRARIES kassert_base
+)

--- a/tests/cmake/KassertTestHelper.cmake
+++ b/tests/cmake/KassertTestHelper.cmake
@@ -24,3 +24,56 @@ function(kassert_register_test KASSERT_TARGET_NAME)
     target_compile_options(${KASSERT_TARGET_NAME} PRIVATE -DKASSERT_EXCEPTION_MODE)
   endif ()
 endfunction()
+
+# Registers a set of tests which should fail to compile.
+#
+# TARGET prefix for the targets to be built
+# FILES the list of files to include in the target
+# SECTIONS sections of the compilation test to build
+# LIBRARIES libraries to link via target_link_libraries(...)
+#
+# Loosely based on: https://stackoverflow.com/questions/30155619/expected-build-failure-tests-in-cmake
+function(kassert_register_compilation_failure_test)
+  cmake_parse_arguments(
+    "KATESTROPHE" # prefix
+    "" # options
+    "TARGET" # one value arguments
+    "FILES;SECTIONS;LIBRARIES" # multiple value arguments
+    ${ARGN}
+    )
+
+  # the file should compile without any section enabled
+  add_executable(${KATESTROPHE_TARGET} ${KATESTROPHE_FILES})
+  target_link_libraries(${KATESTROPHE_TARGET} PUBLIC gtest ${KATESTROPHE_LIBRARIES})
+
+  # For each given section, add a target.
+  foreach(SECTION ${KATESTROPHE_SECTIONS})
+    string(TOLOWER ${SECTION} SECTION_LOWERCASE)
+    set(THIS_TARGETS_NAME "${KATESTROPHE_TARGET}.${SECTION_LOWERCASE}")
+
+    # Add the executable and link the libraries.
+    add_executable(${THIS_TARGETS_NAME} ${KATESTROPHE_FILES})
+    target_link_libraries(${THIS_TARGETS_NAME} PUBLIC gtest ${KATESTROPHE_LIBRARIES})
+
+    # Select the correct section of the target by setting the appropriate preprocessor define.
+    target_compile_definitions(${THIS_TARGETS_NAME} PRIVATE ${SECTION})
+
+    # Exclude the target fromn the "all" target.
+    set_target_properties(
+      ${THIS_TARGETS_NAME} PROPERTIES
+      EXCLUDE_FROM_ALL TRUE
+      EXCLUDE_FROM_DEFAULT_BUILD TRUE
+      )
+
+    # Add a test invoking "cmake --build" to test if the target compiles.
+    add_test(
+      NAME "${THIS_TARGETS_NAME}"
+      COMMAND cmake --build . --target ${THIS_TARGETS_NAME} --config $<CONFIGURATION>
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      )
+
+    # Specify, that the target should not compile.
+    set_tests_properties("${THIS_TARGETS_NAME}" PROPERTIES WILL_FAIL TRUE)
+  endforeach()
+endfunction()
+

--- a/tests/kassert_compilation_failures_test.cpp
+++ b/tests/kassert_compilation_failures_test.cpp
@@ -12,7 +12,7 @@
 // <https://www.gnu.org/licenses/>.
 
 #undef KASSERT_ASSERTION_LEVEL
-#define KASSERT_ASSERTION_LEVEL 3
+#define KASSERT_ASSERTION_LEVEL kassert::assert::normal
 
 #include "kassert/kassert.hpp"
 

--- a/tests/kassert_compilation_failures_test.cpp
+++ b/tests/kassert_compilation_failures_test.cpp
@@ -1,0 +1,27 @@
+// This file is part of KaMPI.ng.
+//
+// Copyright 2022 The KaMPI.ng Authors
+//
+// KaMPI.ng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPI.ng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPI.ng.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+#undef KASSERT_ASSERTION_LEVEL
+#define KASSERT_ASSERTION_LEVEL 3
+
+#include "kassert/kassert.hpp"
+
+int main(int /* argc */, char** /* argv */) {
+#if defined(FORBIDDEN_AND)
+    KASSERT(false && false);
+#elif defined(FORBIDDEN_OR)
+    KASSERT(false || false);
+#else
+    // If none of the above sections is active, this file will compile successfully.
+#endif
+}


### PR DESCRIPTION
Copied the part for compilation failure tests from KaTestrophe. Didn't want to copy KaTestrophe itself since the project should not depend on MPI. 