### PR TITLE
Rename ASSERTION_ENABLED to KASSERT_ASSERTION_ENABLED

### DIFF
--- a/include/kassert/kassert.hpp
+++ b/include/kassert/kassert.hpp
@@ -159,7 +159,7 @@ constexpr bool assertion_enabled(int level) {
 /// \c KASSERT_ASSERTION_LEVEL. This is the macro version of assertion_enabled for use in the preprocessor.
 /// @param level The level of the assertion.
 /// @return Whether the assertion is enabled.
-#define ASSERTION_ENABLED(level) level <= KASSERT_ASSERTION_LEVEL
+#define KASSERT_ASSERTION_ENABLED(level) level <= KASSERT_ASSERTION_LEVEL
 
 /// @brief Evaluates an assertion expression. If the assertion fails, prints an error describing the failed assertion.
 /// @param type Actual type of this check. In exception mode, this parameter has always value \c ASSERTION, otherwise


### PR DESCRIPTION
Same as in kamping but with KASSERT

we should really start using this repo in kamping so we don't have to do everything twice ;)