### PR TITLE
Buffering for Logger

### DIFF
--- a/include/kassert/internal/logger.hpp
+++ b/include/kassert/internal/logger.hpp
@@ -78,7 +78,7 @@ public:
 
     /// @brief Flushes all buffered logs to the underlying stream.
     void flush() {
-        _out << _out_buffer.str();
+        _out << _out_buffer.str() << std::flush;
         _out_buffer.str(std::string{});
     }
 


### PR DESCRIPTION
This prevents interleaving of KASSERT output from multiple MPI ranks.
The logged messages are buffered in a stringstream and buffered content is only
flushed on destruction of the logger, or when `flush()` is called explicitly;