### PR TITLE
Add description to metadata

### DIFF
--- a/docs/custom_doxygen/header.html
+++ b/docs/custom_doxygen/header.html
@@ -9,14 +9,14 @@
 <!-- BEGIN opengraph metadata -->
 <meta property="og:title" content="Kassert - Karlsruhe Assertion Library" />
 <meta property="og:image" content="https://raw.githubusercontent.com/kamping-site/kassert/main/docs/images/logo.svg" />
-<meta property="og:description" content="Powerfull assertions made easy: Define assertion levels, get insights with expression decomposition and switch between exceptions and assertions." />
+<meta property="og:description" content="Powerful assertions made easy: Define assertion levels, get insights with expression decomposition, and switch between exceptions and assertions." />
 <meta property="og:url" content="https://kamping-site.github.io/kassert/" />
 <!-- END opengraph metadata -->
 
 <!-- BEGIN twitter metadata -->
 <meta name="twitter:image:src" content="https://raw.githubusercontent.com/kamping-site/kassert/main/docs/images/logo.svg" />
 <meta name="twitter:title" content="Kassert - Karlsruhe Assertion Library" />
-<meta name="twitter:description" content="Powerfull assertions made easy: Define assertion levels, get insights with expression decomposition and switch between exceptions and assertions." />
+<meta name="twitter:description" content="Powerful assertions made easy: Define assertion levels, get insights with expression decomposition, and switch between exceptions and assertions." />
 <!-- END twitter metadata -->
 
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->

--- a/docs/custom_doxygen/header.html
+++ b/docs/custom_doxygen/header.html
@@ -7,16 +7,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
 <!-- BEGIN opengraph metadata -->
-<meta property="og:title" content="Kassert" />
+<meta property="og:title" content="Kassert - Karlsruhe Assertion Library" />
 <meta property="og:image" content="https://raw.githubusercontent.com/kamping-site/kassert/main/docs/images/logo.svg" />
-<meta property="og:description" content="Karlsruhe Assertion Library." />
+<meta property="og:description" content="Powerfull assertions made easy: Define assertion levels, get insights with expression decomposition and switch between exceptions and assertions." />
 <meta property="og:url" content="https://kamping-site.github.io/kassert/" />
 <!-- END opengraph metadata -->
 
 <!-- BEGIN twitter metadata -->
 <meta name="twitter:image:src" content="https://raw.githubusercontent.com/kamping-site/kassert/main/docs/images/logo.svg" />
-<meta name="twitter:title" content="Kassert" />
-<meta name="twitter:description" content="Karlsruhe Assertion Library." />
+<meta name="twitter:title" content="Kassert - Karlsruhe Assertion Library" />
+<meta name="twitter:description" content="Powerfull assertions made easy: Define assertion levels, get insights with expression decomposition and switch between exceptions and assertions." />
 <!-- END twitter metadata -->
 
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->


### PR DESCRIPTION
I just had a look at what the current version looks like and it's very empty. This is an attempt at making it more pleasing to look at and also give some information.

This is what it currently looks like on mattermost: 
![image](https://user-images.githubusercontent.com/11928343/189669621-9a260006-ca5b-410d-a7af-ccf674eae04c.png)
