### PR TITLE
Don't run code-related workflows when only docs change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
   workflow_dispatch:
 jobs:
   formatting-check:

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
   workflow_dispatch:
 jobs:
   cmake-formatting-check:


### PR DESCRIPTION
I only added the filter to pull requests, so we always get a full picture on main.