### PR TITLE
Make build pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ constexpr int light = KAMPING_ASSERTION_LEVEL_LIGHT;
 
 #define KAMPING_ASSERTION_LEVEL_HEAVY 40
 constexpr int heavy = KAMPING_ASSERTION_LEVEL_HEAVY;
-} // namespace kamping::assert 
+} // namespace kamping::assert
 ```
 
 ## Requirements


### PR DESCRIPTION
Apparently, #44 magically fixed itself. So this is mainly to rerun the build so the latest commit on main is green.

Also, remove a whitespace.