### PR TITLE
Add include guard for kassert target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(
     LANGUAGES CXX
 )
 
+# include guard to prevent duplicate targets when including this project as a subdirectory
+if (TARGET kassert)
+    return()
+endif ()
+
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # folder support for IDEs
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
This prevents duplicate targets when kassert is included by multiple dependencies of another project.